### PR TITLE
Bug(

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -406,7 +406,7 @@ class Connection extends Component
                 $length = $line + 2;
                 $data = '';
                 while ($length > 0) {
-                    if (($block = fread($this->_socket, $line + 2)) === false) {
+                    if (($block = fread($this->_socket, $length)) === false) {
                         throw new Exception("Failed to read from socket.\nRedis command was: " . $command);
                     }
                     $data .= $block;


### PR DESCRIPTION
Looks like there`s a misspelling.
It comes out if you get large portions of data over network and you have to run fread more then once - on the second time it does not get the left part of the line ($length -= mb_strlen($block)), but it gets the whole line length again ($line + 2).
