### PR TITLE
Update redis connection

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -272,7 +272,9 @@ class Connection extends Component
             if ($this->password !== null) {
                 $this->executeCommand('AUTH', [$this->password]);
             }
-            $this->executeCommand('SELECT', [$this->database]);
+            if ($this->database != 0){
+                $this->executeCommand('SELECT', [$this->database]);
+            }
             $this->initConnection();
         } else {
             \Yii::error("Failed to open redis DB connection ($connection): $errorNumber - $errorDescription", __CLASS__);


### PR DESCRIPTION
Another small performance improvement (that`s not compatible with pconnects) - there`s no need to select database if it`s 0, because as redis documentation sais: 'New connections always use DB 0.'.