### PR TITLE
stream_socket_client: On success a stream resource is returned which …

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -227,6 +227,12 @@ class Connection extends Component
      */
     private $_socket;
 
+    /**
+     * @var integer Bitmask field which may be set to any combination of connection flags. Currently the select of connection flags is limited to STREAM_CLIENT_CONNECT (default), STREAM_CLIENT_ASYNC_CONNECT and STREAM_CLIENT_PERSISTENT.
+     * @var [type]
+     */
+    public $socketClientFlags = STREAM_CLIENT_CONNECT;
+
 
     /**
      * Closes the connection when this component is being serialized.
@@ -264,7 +270,8 @@ class Connection extends Component
             $this->unixSocket ? 'unix://' . $this->unixSocket : 'tcp://' . $this->hostname . ':' . $this->port,
             $errorNumber,
             $errorDescription,
-            $this->connectionTimeout ? $this->connectionTimeout : ini_get("default_socket_timeout")
+            $this->connectionTimeout ? $this->connectionTimeout : ini_get("default_socket_timeout"),
+            $this->socketClientFlags
         );
         if ($this->_socket) {
             if ($this->dataTimeout !== null) {

--- a/Connection.php
+++ b/Connection.php
@@ -245,7 +245,7 @@ class Connection extends Component
      */
     public function getIsActive()
     {
-        return $this->_socket !== null;
+        return is_resource($this->_socket);
     }
 
     /**
@@ -255,7 +255,7 @@ class Connection extends Component
      */
     public function open()
     {
-        if ($this->_socket !== null) {
+        if ($this->isActive) {
             return;
         }
         $connection = ($this->unixSocket ?: $this->hostname . ':' . $this->port) . ', database=' . $this->database;
@@ -288,7 +288,7 @@ class Connection extends Component
      */
     public function close()
     {
-        if ($this->_socket !== null) {
+        if ($this->isActive) {
             $connection = ($this->unixSocket ?: $this->hostname . ':' . $this->port) . ', database=' . $this->database;
             \Yii::trace('Closing DB connection: ' . $connection, __METHOD__);
             $this->executeCommand('QUIT');


### PR DESCRIPTION
stream_socket_client: On success a stream resource is returned which may be used together with the other file functions (such as fgets(), fgetss(), fwrite(), fclose(), and feof()), FALSE on failure.

http://php.net/manual/en/function.stream-socket-client.php