### PR TITLE
remove quotes from numeric parts of composite key

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -122,9 +122,10 @@ class ActiveRecord extends BaseActiveRecord
             }
         }
         // save pk in a findall pool
-        $db->executeCommand('RPUSH', [static::keyPrefix(), static::buildKey($pk)]);
+        $pk = static::buildKey($pk);
+        $db->executeCommand('RPUSH', [static::keyPrefix(), $pk]);
 
-        $key = static::keyPrefix() . ':a:' . static::buildKey($pk);
+        $key = static::keyPrefix() . ':a:' . $pk;
         // save attributes
         $setArgs = [$key];
         foreach ($values as $attribute => $value) {
@@ -333,6 +334,6 @@ class ActiveRecord extends BaseActiveRecord
             }
         }
 
-        return md5(json_encode($key));
+        return md5(json_encode($key,JSON_NUMERIC_CHECK));
     }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -111,6 +111,9 @@ class ActiveRecordTest extends TestCase
         $orderItem = new OrderItem();
         $orderItem->setAttributes(['order_id' => 3, 'item_id' => 2, 'quantity' => 1, 'subtotal' => 40.0], false);
         $orderItem->save(false);
+        $orderItem = new OrderItem();
+        $orderItem->setAttributes(['order_id' => 3, 'item_id' => 'nostr', 'quantity' => 1, 'subtotal' => 40.0], false);
+        $orderItem->save(false);
 
         $order = new OrderWithNullFK();
         $order->setAttributes(['customer_id' => 1, 'created_at' => 1325282384, 'total' => 110.0], false);
@@ -200,8 +203,8 @@ class ActiveRecordTest extends TestCase
         $this->assertEquals(1, Customer::find()->min('id'));
         $this->assertEquals(3, Customer::find()->max('id'));
 
-        $this->assertEquals(6, OrderItem::find()->count());
-        $this->assertEquals(7, OrderItem::find()->sum('quantity'));
+        $this->assertEquals(7, OrderItem::find()->count());
+        $this->assertEquals(8, OrderItem::find()->sum('quantity'));
     }
 
     public function testFindIndexBy()
@@ -407,4 +410,17 @@ class ActiveRecordTest extends TestCase
         $this->assertNotNull($customer);
         $this->assertEquals('user6', $customer->name);
     }
+
+    public function testBuildKey()
+    {
+        $pk = ['order_id' => 3, 'item_id' => 'nostr'];
+	$key = OrderItem::buildKey($pk);
+
+        $orderItem = OrderItem::findOne($pk);
+        $this->assertNotNull($orderItem);
+
+        $pk = ['order_id' => $orderItem->order_id, 'item_id' => $orderItem->item_id];
+        $this->assertEquals($key, OrderItem::buildKey($pk));
+    }
+
 }


### PR DESCRIPTION
otherwise buildKey() may return different hashes before saving and after loading from/to redis
before save: {"lid":2,"ltype":"IT"} => 400ae3f5ecbb298e20f1367921c3ed01
after load:     {"lid":"2","ltype":"IT"} => d0534a08a2218cef1df7ad391bbf3bb9

I can not delete record with new hash
"LREM" "List" "0" "d0534a08a2218cef1df7ad391bbf3bb9"
"DEL" "List:a :d0534a08a2218cef1df7ad391bbf3bb9"
because it does not exist.
