### PR TITLE
Fix bug: session_regenerate_id(): Failed to create(read) session ID: user (path: )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 redis extension Change Log
 -----------------------
 
 - Bug #37: Fixed detection of open socket (mirocow)
+- Bug #46: Fixed bug to execute session_regenerate_id in PHP 7.0 (githubjeka)
 - Chg #14: Added missing `BLPOP` to `$redisCommands` (samdark)   
 
 2.0.4 May 10, 2015

--- a/Session.php
+++ b/Session.php
@@ -116,7 +116,7 @@ class Session extends \yii\web\Session
     {
         $data = $this->redis->executeCommand('GET', [$this->calculateKey($id)]);
 
-        return $data === false ? '' : $data;
+        return $data === false || $data === null ? '' : $data;
     }
 
     /**


### PR DESCRIPTION
Fixes for:
https://github.com/yiisoft/yii2-redis/issues/41
https://github.com/yiisoft/yii2/issues/10325