### PR TITLE
with no need  for type cast with the error number

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -291,7 +291,7 @@ class Connection extends Component
         } else {
             \Yii::error("Failed to open redis DB connection ($connection): $errorNumber - $errorDescription", __CLASS__);
             $message = YII_DEBUG ? "Failed to open redis DB connection ($connection): $errorNumber - $errorDescription" : 'Failed to open DB connection.';
-            throw new Exception($message, $errorDescription, (int) $errorNumber);
+            throw new Exception($message, $errorDescription, $errorNumber);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | no

Refer the document http://php.net/manual/en/function.stream-socket-client.php

`errorNumber` will be interger, so we no need a type cast there.

Right?

