### PR TITLE
Avoid class cannot be inherited and used properly

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -238,7 +238,7 @@ class Connection extends Component
     /**
      * @var resource redis socket connection
      */
-    private $_socket = false;
+    protected $_socket = false;
 
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Tests pass?   | yes
| Fixed issues  | the class that inherits the Connection cannot use the $_socket variable.

