### PR TITLE
Limited Twemproxy/nutcracker support

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -283,7 +283,7 @@ class Connection extends Component
             return;
         }
         // twemproxy/nutcrackes doesn't support DB selection
-        if(!$this->twemproxy) {
+        if($this->twemproxy) {
             // in this case database must be always 0.
             $this->database = 0;
         }

--- a/Connection.php
+++ b/Connection.php
@@ -409,15 +409,18 @@ class Connection extends Component
 
         // Retries
         $rcount = 0;
+        $lex = NULL;
         while ($rcount < $this->retriesmax) {
             try {
                 \Yii::trace("Executing Redis Command: {$name} | Try {$rcount}", __METHOD__);
                 fwrite($this->_socket, $command);
                 return $this->parseResponse(implode(' ', $params));
             } catch (Exception $ex) {
+                $lex = $ex;
                 $rcount++;
             }
         }
+        throw $lex;
     }
 
     /**

--- a/Connection.php
+++ b/Connection.php
@@ -53,6 +53,17 @@ class Connection extends Component
      */
     public $port = 6379;
     /**
+     * @var boolean flag to indicate this is a connection to a twemproxy/nutcracker server.
+     * If [[twemproxy]] is true there is no database selection (default is 0),
+     * in order to support failed reponses in case of node failures, retries are enabled.
+     */
+    public $twemproxy = FALSE;
+    /**
+     * @var integer the number of retries before giving up in case of a connection to
+     * twemproxy/nutcracker, it is suggested to set as n° nodes + 1.
+     */
+    public $retriesmax = 1;
+    /**
      * @var string the unix socket path (e.g. `/var/run/redis/redis.sock`) to use for connecting to the redis server.
      * This can be used instead of [[hostname]] and [[port]] to connect to the server using a unix socket.
      * If a unix socket path is specified, [[hostname]] and [[port]] will be ignored.
@@ -271,6 +282,11 @@ class Connection extends Component
         if ($this->_socket !== false) {
             return;
         }
+        // twemproxy/nutcrackes doesn't support DB selection
+        if(!$this->twemproxy) {
+            // in this case database must be always 0.
+            $this->database = 0;
+        }
         $connection = ($this->unixSocket ?: $this->hostname . ':' . $this->port) . ', database=' . $this->database;
         \Yii::trace('Opening redis DB connection: ' . $connection, __METHOD__);
         $this->_socket = @stream_socket_client(
@@ -287,7 +303,7 @@ class Connection extends Component
             if ($this->password !== null) {
                 $this->executeCommand('AUTH', [$this->password]);
             }
-            if ($this->database !== null) {
+            if (!$this->twemproxy && $this->database !== null) {
                 $this->executeCommand('SELECT', [$this->database]);
             }
             $this->initConnection();
@@ -391,10 +407,17 @@ class Connection extends Component
             $command .= '$' . mb_strlen($arg, '8bit') . "\r\n" . $arg . "\r\n";
         }
 
-        \Yii::trace("Executing Redis Command: {$name}", __METHOD__);
-        fwrite($this->_socket, $command);
-
-        return $this->parseResponse(implode(' ', $params));
+        // Retries
+        $rcount = 0;
+        while ($rcount < $this->retriesmax) {
+            try {
+                \Yii::trace("Executing Redis Command: {$name} | Try {$rcount}", __METHOD__);
+                fwrite($this->_socket, $command);
+                return $this->parseResponse(implode(' ', $params));
+            } catch (Exception $ex) {
+                $rcount++;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | n/a
| Fixed issues  | n/a

In order to be able to operate with a twemproxy/nutcracker server I have added two configuration parameter:

- **twemproxy**: is a boolean flag which "switch" the client to operate properly with the proxy server
- **retriesmax**: is the max. number of times a single command is executed in a row until it return an exception.

Twemproxy has several limitations over the standard redis protocol, two of them are the most impacting for my project:
1. The proxy operate only on one database, SELECT command is not recorgnized, so I had to turn it off on opening connection.
2. When node ejection mode is used, due to failures of nodes the proxy can answer to commands with an ERR that could be up to (n° of failed nodes) times in a row for a single command, hence the need to try again the same command up to failed + 1 times before definitively give up and return with an exception as was the normal flow.