### PR TITLE
Fix for sub commands e.g. SCRIPT LOAD

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -355,7 +355,7 @@ class Connection extends Component
     {
         $redisCommand = strtoupper(Inflector::camel2words($name, false));
         if (in_array($redisCommand, $this->redisCommands)) {
-            return $this->executeCommand($name, $params);
+            return $this->executeCommand($redisCommand, $params);
         } else {
             return parent::__call($name, $params);
         }
@@ -385,7 +385,10 @@ class Connection extends Component
     {
         $this->open();
 
-        array_unshift($params, $name);
+        $nameParts = explode(' ', $name);
+
+        $params = array_merge($nameParts, $params);
+
         $command = '*' . count($params) . "\r\n";
         foreach ($params as $arg) {
             $command .= '$' . mb_strlen($arg, '8bit') . "\r\n" . $arg . "\r\n";


### PR DESCRIPTION
| Q                    | A
| ------------- | ---
| Is bugfix?       | yes
| New feature? | no
| Breaks BC?    | no
| Tests pass?   | yes

There was problem with sending wrong variable to executeCommand (probably typo)
Second problem was encoding (similar to https://github.com/PerlRedis/perl-redis/pull/26)