### PR TITLE
Bug #33: Fixed invalid expire time on 32bit platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 redis extension Change Log
 - Enh: Optimized find by PK for relational queries and IN condition (cebe, andruha)
 - Enh #81: Allow setting `Connection::$database` to `null` to avoid sending a `SELECT` command after connection (cebe)
 - Bug #82: Fixed session object destruction failure when key expires (juffin-halli, samdark)  
+- Bug #33: Fixed invalid expire time on 32bit platforms (masterklavi)  
 
 
 2.0.5 March 17, 2016

--- a/Cache.php
+++ b/Cache.php
@@ -125,9 +125,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             return (bool) $this->redis->executeCommand('SET', [$key, $value]);
         } else {
-            $expire = (int) ($expire * 1000);
-
-            return (bool) $this->redis->executeCommand('SET', [$key, $value, 'PX', $expire]);
+            return (bool) $this->redis->executeCommand('SET', [$key, $value, 'EX', $expire]);
         }
     }
 
@@ -146,12 +144,11 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             $this->redis->executeCommand('MSET', $args);
         } else {
-            $expire = (int) ($expire * 1000);
             $this->redis->executeCommand('MULTI');
             $this->redis->executeCommand('MSET', $args);
             $index = [];
             foreach ($data as $key => $value) {
-                $this->redis->executeCommand('PEXPIRE', [$key, $expire]);
+                $this->redis->executeCommand('EXPIRE', [$key, $expire]);
                 $index[] = $key;
             }
             $result = $this->redis->executeCommand('EXEC');
@@ -174,9 +171,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'NX']);
         } else {
-            $expire = (int) ($expire * 1000);
-
-            return (bool) $this->redis->executeCommand('SET', [$key, $value, 'PX', $expire, 'NX']);
+            return (bool) $this->redis->executeCommand('SET', [$key, $value, 'EX', $expire, 'NX']);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   |
| Fixed issues  | #33 #23 

It's better to use `EXPIRE/EX $expire` instead of `PEXPIRE/PX (int)($expire * 1000)`