### PR TITLE
Bug #33: Fixed invalid expire time on 32bit platforms

### DIFF
--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -60,6 +60,29 @@ class RedisCacheTest extends CacheTestCase
         $this->assertFalse($cache->get('expire_testa_ms'));
     }
 
+    public function testExpireIntegerSeconds()
+    {
+        $cache = $this->getCacheInstance();
+
+        $this->assertTrue($cache->set('expire_test_is', 'expire_test_is', 2));
+        sleep(1);
+        $this->assertEquals('expire_test_is', $cache->get('expire_test_is'));
+        sleep(2);
+        $this->assertFalse($cache->get('expire_test_is'));
+    }
+
+    public function testExpireLongSeconds()
+    {
+        $cache = $this->getCacheInstance();
+
+        // (int)(PHP_INT_MAX*1000) === -1000
+        $this->assertTrue($cache->set('expire_test_ls', 'expire_test_ls', PHP_INT_MAX));
+        sleep(2);
+        $this->assertEquals('expire_test_ls', $cache->get('expire_test_ls'));
+        $this->assertLessThan(PHP_INT_MAX-1, Yii::$app->redis->ttl('expire_test_ls'));
+        $this->assertGreaterThan(PHP_INT_MAX-5, Yii::$app->redis->ttl('expire_test_ls'));
+    }
+
     /**
      * Store a value that is 2 times buffer size big
      * https://github.com/yiisoft/yii2/issues/743

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -67,7 +67,7 @@ class RedisCacheTest extends CacheTestCase
         $this->assertTrue($cache->set('expire_test_is', 'expire_test_is', 2));
         sleep(1);
         $this->assertEquals('expire_test_is', $cache->get('expire_test_is'));
-        sleep(2);
+        sleep(3);
         $this->assertFalse($cache->get('expire_test_is'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | 
| Fixed issues  | #33 #23 

It's better to use `EXPIRE/EX $expire` for large expire times instead of `PEXPIRE/PX (int)($expire * 1000)`.
And...**it fixes bug** on large integer values.