### PR TITLE
Bug #33: Fixed invalid expire time on 32bit platforms

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -125,8 +125,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             return (bool) $this->redis->executeCommand('SET', [$key, $value]);
         } else {
-            $expire = (int) ($expire * 1000);
-
+            $expire = round($expire * 1000);
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'PX', $expire]);
         }
     }
@@ -146,7 +145,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             $this->redis->executeCommand('MSET', $args);
         } else {
-            $expire = (int) ($expire * 1000);
+            $expire = round($expire * 1000);
             $this->redis->executeCommand('MULTI');
             $this->redis->executeCommand('MSET', $args);
             $index = [];
@@ -174,8 +173,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'NX']);
         } else {
-            $expire = (int) ($expire * 1000);
-
+            $expire = round($expire * 1000);
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'PX', $expire, 'NX']);
         }
     }

--- a/Cache.php
+++ b/Cache.php
@@ -125,7 +125,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             return (bool) $this->redis->executeCommand('SET', [$key, $value]);
         } else {
-            $expire = round($expire * 1000);
+            $expire = sprintf("%d", $expire * 1000);
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'PX', $expire]);
         }
     }
@@ -145,7 +145,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             $this->redis->executeCommand('MSET', $args);
         } else {
-            $expire = round($expire * 1000);
+            $expire = sprintf("%d", $expire * 1000);
             $this->redis->executeCommand('MULTI');
             $this->redis->executeCommand('MSET', $args);
             $index = [];
@@ -173,7 +173,7 @@ class Cache extends \yii\caching\Cache
         if ($expire == 0) {
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'NX']);
         } else {
-            $expire = round($expire * 1000);
+            $expire = sprintf("%d", $expire * 1000);
             return (bool) $this->redis->executeCommand('SET', [$key, $value, 'PX', $expire, 'NX']);
         }
     }

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace yiiunit\extensions\redis;
 
+use Yii;
 use yii\redis\Cache;
 use yii\redis\Connection;
 use yiiunit\framework\caching\CacheTestCase;
@@ -82,7 +83,7 @@ class RedisCacheTest extends CacheTestCase
         // on 64-bit: PHP_INT_MAX === 9223372036854775807
         //      max ttl (in SETEX, sec) is about PHP_INT_MAX * 1e-4
         //      max ttl (in PSETEX, ms) is about PHP_INT_MAX * 1e-1
-        $ttl = PHP_INT_MAX * 1e-5;
+        $ttl = PHP_INT_MAX * 1e-4;
         $this->assertTrue($cache->set('expire_test_ls', 'expire_test_ls', $ttl));
         sleep(2);
         $this->assertEquals('expire_test_ls', $cache->get('expire_test_ls'));

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -76,13 +76,13 @@ class RedisCacheTest extends CacheTestCase
         $cache = $this->getCacheInstance();
 
         // on 32-bit: PHP_INT_MAX === 2147483647
-        //      max ttl (in SETEX, sec) is PHP_INT_MAX * 1e6
-        //      max ttl (in PSETEX, ms) is PHP_INT_MAX * 1e9
+        //      max ttl (in SETEX, sec) is about PHP_INT_MAX * 1e6
+        //      max ttl (in PSETEX, ms) is about PHP_INT_MAX * 1e9
         //
         // on 64-bit: PHP_INT_MAX === 9223372036854775807
-        //      max ttl (in SETEX, sec) is PHP_INT_MAX * 1e-4
-        //      max ttl (in PSETEX, ms) is PHP_INT_MAX * 1e-1
-        $ttl = PHP_INT_MAX * 1e-4;
+        //      max ttl (in SETEX, sec) is about PHP_INT_MAX * 1e-4
+        //      max ttl (in PSETEX, ms) is about PHP_INT_MAX * 1e-1
+        $ttl = PHP_INT_MAX * 1e-5;
         $this->assertTrue($cache->set('expire_test_ls', 'expire_test_ls', $ttl));
         sleep(2);
         $this->assertEquals('expire_test_ls', $cache->get('expire_test_ls'));

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -83,7 +83,7 @@ class RedisCacheTest extends CacheTestCase
         // on 64-bit: PHP_INT_MAX === 9223372036854775807
         //      max ttl (in SETEX, sec) is about PHP_INT_MAX * 1e-4
         //      max ttl (in PSETEX, ms) is about PHP_INT_MAX * 1e-1
-        $ttl = PHP_INT_MAX * 1e-4;
+        $ttl = PHP_INT_MAX * 1e-5;
         $this->assertTrue($cache->set('expire_test_ls', 'expire_test_ls', $ttl));
         sleep(2);
         $this->assertEquals('expire_test_ls', $cache->get('expire_test_ls'));

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -83,7 +83,7 @@ class RedisCacheTest extends CacheTestCase
         // on 64-bit: PHP_INT_MAX === 9223372036854775807
         //      max ttl (in SETEX, sec) is about PHP_INT_MAX * 1e-4
         //      max ttl (in PSETEX, ms) is about PHP_INT_MAX * 1e-1
-        $ttl = PHP_INT_MAX * 1e-5;
+        $ttl = 2147483647;
         $this->assertTrue($cache->set('expire_test_ls', 'expire_test_ls', $ttl));
         sleep(2);
         $this->assertEquals('expire_test_ls', $cache->get('expire_test_ls'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #33 #23 

**on 32-bit: `PHP_INT_MAX === 2147483647`**
      integer value of `PHP_INT_MAX * 1000`: `(int)(PHP_INT_MAX * 1000) === -1000`
      double value of `PHP_INT_MAX * 1000`: `round(PHP_INT_MAX * 1000) === 2147483647000`
      max ttl (in SETEX, sec) is `PHP_INT_MAX * 1e6`
      max ttl (in PSETEX, ms) is `PHP_INT_MAX * 1e9`

**on 64-bit: `PHP_INT_MAX === 9223372036854775807`**
      integer value of `PHP_INT_MAX * 1000`: `(int)(PHP_INT_MAX * 1000) === 0`
      double value of `PHP_INT_MAX * 1000`: `round(PHP_INT_MAX * 1000) === 9.2233720368548E+21`
      max ttl (in SETEX, sec) is `PHP_INT_MAX * 1e-4`
      max ttl (in PSETEX, ms) is `PHP_INT_MAX * 1e-1`