### PR TITLE
Fix class resolution in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ before_script:
   - |
     if [ $TRAVIS_PHP_VERSION = '5.6' ]; then
       PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
+    else
+      phpenv config-rm xdebug.ini || return 0
     fi
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "autoload": {
         "psr-4": { "yii\\redis\\": "" }
     },
+    "autoload-dev": {
+        "psr-4": { "yiiunit\\extensions\\redis\\": "tests/"}
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,8 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
-    ]
+    ],
+    "require-dev": {
+        "yiisoft/yii2-dev": "~2.0.13"
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,4 +13,3 @@ require_once __DIR__ . '/compatibility.php';
 require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 Yii::setAlias('@yiiunit', '@yii/../tests');
-Yii::setAlias('@yiiunit/extensions/redis', __DIR__);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,38 +12,5 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 require_once __DIR__ . '/compatibility.php';
 require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
+Yii::setAlias('@yiiunit', '@yii/../tests');
 Yii::setAlias('@yiiunit/extensions/redis', __DIR__);
-Yii::setAlias('@yii/redis', dirname(__DIR__));
-
-if (!class_exists('yiiunit\framework\ar\ActiveRecordTestTrait')) {
-    if (is_file(__DIR__ . '/../../../tests/framework/ar/ActiveRecordTestTrait.php')) {
-        require_once(__DIR__ . '/../../../tests/framework/ar/ActiveRecordTestTrait.php');
-    } elseif (is_file(__DIR__ . '/ActiveRecordTestTrait.php')) {
-        require_once(__DIR__ . '/ActiveRecordTestTrait.php');
-    } else {
-        file_put_contents(__DIR__ . '/ActiveRecordTestTrait.php', file_get_contents('https://raw.githubusercontent.com/yiisoft/yii2/master/tests/framework/ar/ActiveRecordTestTrait.php'));
-        require_once(__DIR__ . '/ActiveRecordTestTrait.php');
-    }
-}
-
-if (!class_exists('yiiunit\TestCase')) {
-    if (is_file(__DIR__ . '/../../../tests/TestCase.php')) {
-        require_once(__DIR__ . '/../../../tests/TestCase.php');
-    } elseif (is_file(__DIR__ . '/BaseTestCase.php')) {
-        require_once(__DIR__ . '/BaseTestCase.php');
-    } else {
-        file_put_contents(__DIR__ . '/BaseTestCase.php', file_get_contents('https://raw.githubusercontent.com/yiisoft/yii2/master/tests/TestCase.php'));
-        require_once(__DIR__ . '/BaseTestCase.php');
-    }
-}
-
-if (!class_exists('yiiunit\framework\caching\CacheTestCase')) {
-    if (is_file(__DIR__ . '/../../../tests/framework/caching/CacheTestCase.php')) {
-        require_once(__DIR__ . '/../../../tests/framework/caching/CacheTestCase.php');
-    } elseif (is_file(__DIR__ . '/CacheTestCase.php')) {
-        require_once(__DIR__ . '/CacheTestCase.php');
-    } else {
-        file_put_contents(__DIR__ . '/CacheTestCase.php', file_get_contents('https://raw.githubusercontent.com/yiisoft/yii2/master/tests/framework/caching/CacheTestCase.php'));
-        require_once(__DIR__ . '/CacheTestCase.php');
-    }
-}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #138 

Also PR has minor improvements:
* Rely on composer autoloader for test namespace resolution
* Disable xdebug extension in tests when PhpUnit runs without coverage