### PR TITLE
Increase frequency of lock tries when `$timeout` is used in `yii\redis\Mutex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 redis extension Change Log
 ------------------------
 
 - Enh #195: Use `Instance::ensure()` to initialize `Session::$redis` (rob006)
+- Enh #199: Increase frequency of lock tries when `$timeout` is used in `Mutex::acquire()` (rob006)
 
 
 2.0.11 November 05, 2019

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "~2.0.14"
+        "yiisoft/yii2": "~2.0.16"
     },
     "require-dev": {
         "phpunit/phpunit": "<7",
-        "yiisoft/yii2-dev": "~2.0.14"
+        "yiisoft/yii2-dev": "~2.0.16"
     },
     "autoload": {
         "psr-4": { "yii\\redis\\": "src" }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

It ports enhancements made in https://github.com/yiisoft/yii2/pull/16839 to redis mutex.