### PR TITLE
Better handle `cache/flush-all` command when cache component is using shared database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.12 under development
 ------------------------
 
+- Bug #182: Better handle `cache/flush-all` command when cache component is using shared database (rob006)
 - Enh #195: Use `Instance::ensure()` to initialize `Session::$redis` (rob006)
 - Enh #199: Increase frequency of lock tries when `$timeout` is used in `Mutex::acquire()` (rob006)
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -146,6 +146,7 @@ class Cache extends \yii\caching\Cache
      * command, component will iterate through all keys in database and remove only these with matching [[$keyPrefix]].
      * Note that this will no longer be an atomic operation and it is much less efficient than `FLUSHDB` command. It is
      * recommended to use separate database for cache and leave this value as `false`.
+     * @since 2.0.12
      */
     public $shareDatabase = false;
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -16,12 +16,15 @@ use yii\di\Instance;
  *
  * Redis Cache requires redis version 2.6.12 or higher to work properly.
  *
- * It needs to be configured with a redis [[Connection]] that is also configured as an application component.
- * By default it will use the `redis` application component.
+ * It needs to be configured with a redis [[Connection]]. By default it will use the `redis` application component.
  *
- * See [[Cache]] manual for common cache operations that redis Cache supports.
+ * > Note: It is recommended to use separate [[Connection::$database|database]] for cache and do not share it with
+ * > other components. If you need to share database, you should set [[$shareDatabase]] to `true` and make sure that
+ * > [[$keyPrefix]] has unique value which will allow to distinguish between cache keys and other data in database.
  *
- * Unlike the [[Cache]], redis Cache allows the expire parameter of [[set]], [[add]], [[mset]] and [[madd]] to
+ * See [[yii\caching\Cache]] manual for common cache operations that redis Cache supports.
+ *
+ * Unlike the [[yii\caching\Cache]], redis Cache allows the expire parameter of [[set]], [[add]], [[mset]] and [[madd]] to
  * be a floating point number, so you may specify the time in milliseconds (e.g. 0.1 will be 100 milliseconds).
  *
  * To use redis Cache as the cache application component, configure the application as follows,
@@ -137,6 +140,14 @@ class Cache extends \yii\caching\Cache
      * @since 2.0.11
      */
     public $forceClusterMode;
+    /**
+     * @var bool whether redis [[Connection::$database|database]] is shared and can contain other data than cache.
+     * Setting this to `true` will change [[flush()]] behavior - instead of using `FLUSHDB` command, component will
+     * iterate through all keys in database and remove only these with matching [[$keyPrefix]]. Note that this is no
+     * longer atomic operation and it is much less efficient than `FLUSHDB` command. It is recommended to use separate
+     * database for cache and leave this value as `false`.
+     */
+    public $shareDatabase = false;
 
     /**
      * @var Connection currently active connection.
@@ -334,6 +345,17 @@ class Cache extends \yii\caching\Cache
      */
     protected function flushValues()
     {
+        if ($this->shareDatabase) {
+            $cursor = 0;
+            do {
+                list($cursor, $keys) = $this->redis->scan($cursor, 'MATCH', $this->keyPrefix . '*');
+                $cursor = (int) $cursor;
+                $this->redis->executeCommand('DEL', $keys);
+            } while ($cursor !== 0);
+
+            return true;
+        }
+
         return $this->redis->executeCommand('FLUSHDB');
     }
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -142,10 +142,10 @@ class Cache extends \yii\caching\Cache
     public $forceClusterMode;
     /**
      * @var bool whether redis [[Connection::$database|database]] is shared and can contain other data than cache.
-     * Setting this to `true` will change [[flush()]] behavior - instead of using `FLUSHDB` command, component will
-     * iterate through all keys in database and remove only these with matching [[$keyPrefix]]. Note that this is no
-     * longer atomic operation and it is much less efficient than `FLUSHDB` command. It is recommended to use separate
-     * database for cache and leave this value as `false`.
+     * Setting this to `true` will change [[flush()]] behavior - instead of using [`FLUSHDB`](https://redis.io/commands/flushdb)
+     * command, component will iterate through all keys in database and remove only these with matching [[$keyPrefix]].
+     * Note that this will no longer be an atomic operation and it is much less efficient than `FLUSHDB` command. It is
+     * recommended to use separate database for cache and leave this value as `false`.
      */
     public $shareDatabase = false;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #182

fix #182
