### PR TITLE
Fix 'DEL' command in `Cache::flushValues()` when `$shareDatabase` is enabled

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -351,7 +351,9 @@ class Cache extends \yii\caching\Cache
             do {
                 list($cursor, $keys) = $this->redis->scan($cursor, 'MATCH', $this->keyPrefix . '*');
                 $cursor = (int) $cursor;
-                $this->redis->executeCommand('DEL', $keys);
+                if (!empty($keys)) {
+                    $this->redis->executeCommand('DEL', $keys);
+                }
             } while ($cursor !== 0);
 
             return true;


### PR DESCRIPTION
refs #200

Fix for https://travis-ci.com/yiisoft/yii2-redis/builds/150207300 - `$keys` may be empty in some cases.