### PR TITLE
Fix #191: getIsActive() returns true when socket is not connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 redis extension Change Log
 ------------------------
 
 - Bug #182: Better handle `cache/flush-all` command when cache component is using shared database (rob006)
+- Bug #191: getIsActive() returns true when socket is not connected (mdx86)
 - Enh #195: Use `Instance::ensure()` to initialize `Session::$redis` (rob006)
 - Enh #199: Increase frequency of lock tries when `$timeout` is used in `Mutex::acquire()` (rob006)
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -566,7 +566,7 @@ class Connection extends Component
      */
     public function getIsActive()
     {
-        return ArrayHelper::getValue($this->_pool, "$this->hostname:$this->port") !== false;
+        return ArrayHelper::getValue($this->_pool, "$this->hostname:$this->port", false) !== false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #191
