### PR TITLE
Redis 5.0 stream command allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ Yii Framework 2 redis extension Change Log
 
 2.0.13 under development
 ------------------------
-- Redis 5.0 stream commands added. Read more at [streams intro](https://redis.io/topics/streams-intro).
-- no changes in this release.
+
+- Enh #210: Add Redis 5.0 stream commands. Read more at [streams intro](https://redis.io/topics/streams-intro) (sartor)
 
 
 2.0.12 March 13, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii Framework 2 redis extension Change Log
 
 2.0.13 under development
 ------------------------
-
+- Redis 5.0 stream commands added. Read more at [streams intro](https://redis.io/topics/streams-intro).
 - no changes in this release.
 
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -200,6 +200,19 @@ use yii\helpers\VarDumper;
  * @method mixed unwatch() Forget about all watched keys. <https://redis.io/commands/unwatch>
  * @method mixed wait($numslaves, $timeout) Wait for the synchronous replication of all the write commands sent in the context of the current connection. <https://redis.io/commands/wait>
  * @method mixed watch(...$keys) Watch the given keys to determine execution of the MULTI/EXEC block. <https://redis.io/commands/watch>
+ * @method mixed xack($stream, $group, ...$ids) Removes one or multiple messages from the pending entries list (PEL) of a stream consumer group <https://redis.io/commands/xack>
+ * @method mixed xadd($stream, $id, $field, $value, ...$fieldsValues) Appends the specified stream entry to the stream at the specified key <https://redis.io/commands/xadd>
+ * @method mixed xclaim($stream, $group, $consumer, $minIdleTimeMs, $id, ...$options) Changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument <https://redis.io/commands/xclaim>
+ * @method mixed xdel($stream, ...$ids) Removes the specified entries from a stream, and returns the number of entries deleted <https://redis.io/commands/xdel>
+ * @method mixed xgroup($subCommand, $stream, $group, ...$options) Manages the consumer groups associated with a stream data structure <https://redis.io/commands/xgroup>
+ * @method mixed xinfo($subCommand, $stream, ...$options) Retrieves different information about the streams and associated consumer groups <https://redis.io/commands/xinfo>
+ * @method mixed xlen($stream) Returns the number of entries inside a stream <https://redis.io/commands/xlen>
+ * @method mixed xpending($stream, $group, ...$options) Fetching data from a stream via a consumer group, and not acknowledging such data, has the effect of creating pending entries <https://redis.io/commands/xpending>
+ * @method mixed xrange($stream, $start, $end, ...$options) Returns the stream entries matching a given range of IDs <https://redis.io/commands/xrange>
+ * @method mixed xread(...$options) Read data from one or multiple streams, only returning entries with an ID greater than the last received ID reported by the caller <https://redis.io/commands/xread>
+ * @method mixed xreadgroup($subCommand, $group, $consumer, ...$options) Special version of the XREAD command with support for consumer groups <https://redis.io/commands/xreadgroup>
+ * @method mixed xrevrange($stream, $end, $start, ...$options) Exactly like XRANGE, but with the notable difference of returning the entries in reverse order, and also taking the start-end range in reverse order <https://redis.io/commands/xrevrange>
+ * @method mixed xtrim($stream, $strategy, ...$options) Trims the stream to a given number of items, evicting older items (items with lower IDs) if needed <https://redis.io/commands/xtrim>
  * @method mixed zadd($key, ...$options) Add one or more members to a sorted set, or update its score if it already exists. <https://redis.io/commands/zadd>
  * @method mixed zcard($key) Get the number of members in a sorted set. <https://redis.io/commands/zcard>
  * @method mixed zcount($key, $min, $max) Count the members in a sorted set with scores within the given values. <https://redis.io/commands/zcount>
@@ -499,6 +512,19 @@ class Connection extends Component
         'UNWATCH', // Forget about all watched keys
         'WAIT', // Wait for the synchronous replication of all the write commands sent in the context of the current connection
         'WATCH', // Watch the given keys to determine execution of the MULTI/EXEC block
+        'XACK', // Removes one or multiple messages from the pending entries list (PEL) of a stream consumer group
+        'XADD', // Appends the specified stream entry to the stream at the specified key
+        'XCLAIM', // Changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument
+        'XDEL', // Removes the specified entries from a stream, and returns the number of entries deleted
+        'XGROUP', // Manages the consumer groups associated with a stream data structure
+        'XINFO', // Retrieves different information about the streams and associated consumer groups
+        'XLEN', // Returns the number of entries inside a stream
+        'XPENDING', // Fetching data from a stream via a consumer group, and not acknowledging such data, has the effect of creating pending entries
+        'XRANGE', // Returns the stream entries matching a given range of IDs
+        'XREAD', // Read data from one or multiple streams, only returning entries with an ID greater than the last received ID reported by the caller
+        'XREADGROUP', // Special version of the XREAD command with support for consumer groups
+        'XREVRANGE', // Exactly like XRANGE, but with the notable difference of returning the entries in reverse order, and also taking the start-end range in reverse order
+        'XTRIM', // Trims the stream to a given number of items, evicting older items (items with lower IDs) if needed
         'ZADD', // Add one or more members to a sorted set, or update its score if it already exists
         'ZCARD', // Get the number of members in a sorted set
         'ZCOUNT', // Count the members in a sorted set with scores within the given values


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | not sure
| Tests pass?   | yes

This PR adds new Redis 5.0 stream commands.
I have copied commands description from official documentation with minimal editing.
Class annotations also updated for new commands
