### PR TITLE
Connection::isActive() returns FALSE when the connection is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.14 under development
 ------------------------
 
-- no changes in this release.
+- Bug #215: Fix `Connection::isActive()` returns `false` when the connection is active (cornernote)
 
 
 2.0.13 May 02, 2020

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -597,7 +597,7 @@ class Connection extends Component
      */
     public function getIsActive()
     {
-        return ArrayHelper::getValue($this->_pool, "$this->hostname:$this->port", false) !== false;
+        return ArrayHelper::getValue($this->_pool, $this->connectionString, false) !== false;
     }
 
     /**


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes/no ?
| Tests pass?   | yes/no ?
| Fixed issues  | #215
