### PR TITLE
Feature/ssl context configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.15 under development
 ------------------------
 
-- no changes in this release.
+- Enh #227: Added support for adjusting PHP context options and parameters. This allows e.g. supporting self-signed certificates.
 
 
 2.0.14 November 10, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.15 under development
 ------------------------
 
-- Enh #227: Added support for adjusting PHP context options and parameters. This allows e.g. supporting self-signed certificates.
+- Enh #227: Added support for adjusting PHP context options and parameters. This allows e.g. supporting self-signed certificates (akselikap)
 
 
 2.0.14 November 10, 2020

--- a/README.md
+++ b/README.md
@@ -74,28 +74,12 @@ return [
             'port' => 6380,
             'database' => 0,
             'useSSL' => true,
-        ],
-    ],
-];
-```
-
-**SSL configuration with self-signed certificates** NOTE: This has security implications.
-You can use all SSL context options listed here: https://www.php.net/manual/en/context.ssl.php.
-Example:
-```php
-return [
-    //....
-    'components' => [
-        'redis' => [
-            'class' => 'yii\redis\Connection',
-            'hostname' => 'localhost',
-            'port' => 6380,
-            'database' => 0,
-            'useSSL' => true,
-            'sslContextOptions' => [
-                'verify_peer'       => false,
-                'verify_peer_name'  => false,
-                'allow_self_signed' => true,
+            // Use contextOptions for more control over the connection (https://www.php.net/manual/en/context.php), not usually needed
+            'contextOptions' => [
+                'ssl' => [
+                    'local_cert' => '/path/to/local/certificate',
+                    'local_pk' => '/path/to/local/private_key',
+                ],
             ],
         ],
     ],

--- a/README.md
+++ b/README.md
@@ -78,3 +78,26 @@ return [
     ],
 ];
 ```
+
+**SSL configuration with self-signed certificates** NOTE: This has security implications.
+You can use all SSL context options listed here: https://www.php.net/manual/en/context.ssl.php.
+Example:
+```php
+return [
+    //....
+    'components' => [
+        'redis' => [
+            'class' => 'yii\redis\Connection',
+            'hostname' => 'localhost',
+            'port' => 6380,
+            'database' => 0,
+            'useSSL' => true,
+            'sslContextOptions' => stream_context_create(['ssl' => [
+                'verify_peer'       => false,
+                'verify_peer_name'  => false,
+                'allow_self_signed' => true,
+            ]]),
+        ],
+    ],
+];
+```

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ return [
             'port' => 6380,
             'database' => 0,
             'useSSL' => true,
-            'sslContextOptions' => stream_context_create(['ssl' => [
+            'sslContextOptions' => [
                 'verify_peer'       => false,
                 'verify_peer_name'  => false,
                 'allow_self_signed' => true,
-            ]]),
+            ],
         ],
     ],
 ];

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -300,6 +300,12 @@ class Connection extends Component
      */
     public $useSSL = false;
     /**
+     * @var array SSL context options: https://www.php.net/manual/en/context.ssl.php
+     * @since 2.x
+     */
+
+    public $sslContextOptions = null;
+    /**
      * @var integer Bitmask field which may be set to any combination of connection flags passed to [stream_socket_client()](https://www.php.net/manual/en/function.stream-socket-client.php).
      * Currently the select of connection flags is limited to `STREAM_CLIENT_CONNECT` (default), `STREAM_CLIENT_ASYNC_CONNECT` and `STREAM_CLIENT_PERSISTENT`.
      *
@@ -618,7 +624,8 @@ class Connection extends Component
             $errorNumber,
             $errorDescription,
             $this->connectionTimeout ?: ini_get('default_socket_timeout'),
-            $this->socketClientFlags
+            $this->socketClientFlags,
+            $this->sslContextOptions
         );
 
         if ($socket) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -625,9 +625,7 @@ class Connection extends Component
             $errorDescription,
             $this->connectionTimeout ?: ini_get('default_socket_timeout'),
             $this->socketClientFlags,
-            $this->sslContextOptions ?
-                stream_context_create(['ssl' => $this->sslContextOptions])
-                : stream_context_create(),
+            $this->sslContextOptions ? stream_context_create(['ssl' => $this->sslContextOptions]) : stream_context_create()
         );
 
         if ($socket) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -300,11 +300,11 @@ class Connection extends Component
      */
     public $useSSL = false;
     /**
-     * @var array SSL context options: https://www.php.net/manual/en/context.ssl.php
+     * @var array PHP context options https://www.php.net/manual/en/context.ssl.php which are used in the Redis connection stream.
      * @since 2.x
      */
 
-    public $sslContextOptions = null;
+    public $contextOptions = [];
     /**
      * @var integer Bitmask field which may be set to any combination of connection flags passed to [stream_socket_client()](https://www.php.net/manual/en/function.stream-socket-client.php).
      * Currently the select of connection flags is limited to `STREAM_CLIENT_CONNECT` (default), `STREAM_CLIENT_ASYNC_CONNECT` and `STREAM_CLIENT_PERSISTENT`.
@@ -625,7 +625,7 @@ class Connection extends Component
             $errorDescription,
             $this->connectionTimeout ?: ini_get('default_socket_timeout'),
             $this->socketClientFlags,
-            $this->sslContextOptions ? stream_context_create(['ssl' => $this->sslContextOptions]) : stream_context_create()
+            stream_context_create($this->contextOptions)
         );
 
         if ($socket) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -625,7 +625,9 @@ class Connection extends Component
             $errorDescription,
             $this->connectionTimeout ?: ini_get('default_socket_timeout'),
             $this->socketClientFlags,
-            $this->sslContextOptions
+            $this->sslContextOptions ?
+                stream_context_create(['ssl' => $this->sslContextOptions])
+                : stream_context_create(),
         );
 
         if ($socket) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -300,10 +300,10 @@ class Connection extends Component
      */
     public $useSSL = false;
     /**
-     * @var array PHP context options https://www.php.net/manual/en/context.ssl.php which are used in the Redis connection stream.
-     * @since 2.x
+     * @var array PHP context options which are used in the Redis connection stream.
+     * @see https://www.php.net/manual/en/context.ssl.php
+     * @since 2.0.15
      */
-
     public $contextOptions = [];
     /**
      * @var integer Bitmask field which may be set to any combination of connection flags passed to [stream_socket_client()](https://www.php.net/manual/en/function.stream-socket-client.php).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes (sort of, I'm experiencing failures on every 2 to 3 runs. I suppose this is related to my Redis which is just a docker run command without any configuration)
| Fixed issues  | I didn't see any related to this

At the moment it's impossible to use a Redis which uses a self-signed certificate. This PR adds a new option sslContextOptions which exposes the ssl context options (https://www.php.net/manual/en/context.ssl.php) to users. The only thing I'm not 100% sure of is whether or not the stream_context_create -function returns the default settings which would be used anyway if it's called without any parameters. I assume this is the case but someone who has more knowledge could confirm that.
