### PR TITLE
Fix #223: Add `Connection::$username` for using username for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.16 under development
 ------------------------
 
-- no changes in this release.
+- Enh #223: Add `Connection::$username` for using username for authentication (samdark, rvkulikov)
 
 
 2.0.15 May 05, 2021

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -277,6 +277,14 @@ class Connection extends Component
      */
     public $unixSocket;
     /**
+     * @var string|null username for establishing DB connection. Defaults to `null` meaning AUTH command will be performed without username.
+     * Username was introduced in Redis 6.
+     * @link https://redis.io/commands/auth
+     * @link https://redis.io/topics/acl
+     * @since 2.0.16
+     */
+    public $username;
+    /**
      * @var string the password for establishing DB connection. Defaults to null meaning no AUTH command is sent.
      * See https://redis.io/commands/auth
      */
@@ -638,7 +646,7 @@ class Connection extends Component
                 stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
             }
             if ($this->password !== null) {
-                $this->executeCommand('AUTH', [$this->password]);
+                $this->executeCommand('AUTH', array_filter([$this->username, $this->password]));
             }
             if ($this->database !== null) {
                 $this->executeCommand('SELECT', [$this->database]);

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -158,7 +158,7 @@ class ActiveRecordTest extends TestCase
         $orderItem->setAttributes(['order_id' => 2, 'item_id' => 5, 'quantity' => 1, 'subtotal' => 15.0], false);
         $orderItem->save(false);
         $orderItem = new OrderItemWithNullFK();
-        $orderItem->setAttributes(['order_id' => 2, 'item_id' => 3, 'quantity' => 1, 'subtotal' => 8.0], false);
+        $orderItem->setAttributes(['order_id' => 2, 'item_id' => 5, 'quantity' => 1, 'subtotal' => 8.0], false);
         $orderItem->save(false);
         $orderItem = new OrderItemWithNullFK();
         $orderItem->setAttributes(['order_id' => 3, 'item_id' => 2, 'quantity' => 1, 'subtotal' => 40.0], false);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | #223
