### PR TITLE
Bugfix: `Cache::getValue()` should return `false` in case of missing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.18 under development
 ------------------------
 
-- no changes in this release.
+- Bug #247: `Cache::getValue()` now returns `false` in case of missing key (rhertogh)
 
 
 2.0.17 January 11, 2022

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,16 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to follow the instructions
 for both A and B.
 
+Upgrade from 2.0.17
+------------------
+
+* The `Cache::getValue()` method now adheres to the specifications and returns `false` in case of a missing 
+  (or expired) key. This might have impact in the following scenarios:  
+  * You specified a custom `Cache::$serializer`, depending on the serializer used `Cache::get()` might now 
+    return `false` instead of `null` in case of a missing (or expired) key.
+  * You extended the `Cache` class, are using the protected method `Cache::getValue()` directly and expect 
+    a return value of `null` in case of a missing (or expired) key.
+
 Upgrade from 2.0.13
 ------------------
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -195,7 +195,12 @@ class Cache extends \yii\caching\Cache
      */
     protected function getValue($key)
     {
-        return $this->getReplica()->executeCommand('GET', [$key]);
+        $value = $this->getReplica()->executeCommand('GET', [$key]);
+        if ($value === null) {
+            return false; // Key is not in the cache or expired
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌ (It now adheres to the documentation, but the return value is changed)
| Fixed issues  | yiisoft/yii2/pull/19396

According to `\yii\caching\Cache::getValue()` the return value should be "false if the value is not in the cache or expired".

Currently `null` is returned by the `getValue()` method. When no `serializer` is specified that `null` is casted to a string and the native `unserialize()` function is used in `\yii\caching\Cache::get()`. The `unserialize()` function returns `false` on failure, this actually causes the `get` method to return the correct value.
However, when a `serializer` is specified (e.g. igbinary_unserialize) the `null` value from `getValue()` is not casted into a string. On PHP 8.1 this causes an error since a string is expected (https://www.php.net/manual/en/function.igbinary-unserialize.php).
When the `getValue()` method would have returned the expected `false`, the `get()` method would have returned it as is without trying to unserialize it, avoiding the error ([yiisoft/yii2/blob/master/framework/caching/Cache.php#L135](https://github.com/yiisoft/yii2/blob/master/framework/caching/Cache.php#L135)).

This PR fixes the `Cache::getValue()` method by returning `false` when the requested key is not found.
