### PR TITLE
feat: Added support to set a scheme for keys of Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 redis extension Change Log
 
 - Bug #247: `Cache::getValue()` now returns `false` in case of missing key (rhertogh)
 - Enh #249 Added support to set the redis scheme to tls. Add to configuration: `'scheme' => 'tls'` (tychovbh)
+- Enh #253 Added support to set a scheme for keys of Session. Added `Session::$objectType` and `Session::usePrefixInSchema` (githubjeka)
 
 
 2.0.17 January 11, 2022

--- a/src/Session.php
+++ b/src/Session.php
@@ -71,7 +71,17 @@ class Session extends \yii\web\Session
      * static value if the cached data needs to be shared among multiple applications.
      */
     public $keyPrefix;
-
+    /**
+     * @var string a string which is used in a schema for key as object-type
+     * Note: Try to stick with a schema. For instance "object-type:id" is a good idea, as in "user:1000".
+     * @see https://redis.io/docs/data-types/tutorial/#keys
+     */
+    public $objectType = '';
+    /**
+     * @var bool if true [[$keyPrefix]] will used after [[$objectType]] in a schema for key as objectType:keyPrefix:id
+     * Note: Ignore if [[$objectType]] is empty
+     */
+    public $usePrefixInSchema = false;
 
     /**
      * Initializes the redis Session component.
@@ -167,6 +177,13 @@ class Session extends \yii\web\Session
      */
     protected function calculateKey($id)
     {
-        return $this->keyPrefix . md5(json_encode([__CLASS__, $id]));
+        $hash = md5(json_encode([__CLASS__, $id]));
+        if (strlen($this->objectType) > 0) {
+            if ($this->usePrefixInSchema) {
+                return $this->objectType . ':' . $this->keyPrefix . ':' . $hash;
+            }
+            return $this->objectType . ':' . $this->keyPrefix . $hash;
+        }
+        return $this->keyPrefix . $hash;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

see https://redis.io/docs/data-types/tutorial/#keys

Now session in Redis storage like list of keys 
![image](https://user-images.githubusercontent.com/874234/186881621-cf58977a-e0d0-43e5-bc06-3e67b307d65b.png)

Some GUI Redis support schema for key. Useful when big data.

![image](https://user-images.githubusercontent.com/874234/186881825-0ef860e4-22d0-41ab-ae07-2fe3887e98b7.png)

But redis session component can't save data by schema for key. PR makes it possible



