### PR TITLE
Fix Issue template typo in `vesion`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,8 +12,8 @@ Yii communities listed at https://github.com/yiisoft/yii2/wiki/communities
 
 ### Additional info
 
-| Q                | A
-| ---------------- | ---
-| Yii vesion       |
-| PHP version      |
-| Operating system |
+| Q                | A |
+|------------------|---|
+| Yii version      |   |
+| PHP version      |   |
+| Operating system |   |

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,8 +12,8 @@ Yii communities listed at https://github.com/yiisoft/yii2/wiki/communities
 
 ### Additional info
 
-| Q                | A |
-|------------------|---|
-| Yii version      |   |
-| PHP version      |   |
-| Operating system |   |
+| Q                | A 
+|------------------|---
+| Yii version      |   
+| PHP version      |   
+| Operating system |   


### PR DESCRIPTION
`Yii vesion` had a typo, replaced with `version`.
Reformatted the table, too.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
