### PR TITLE
Prevent nullable param on mb_strlen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.20 under development
 ------------------------
 
-- Bug #270: Prevent null parameter on `mb_strlen` to avoid [PHP 8.4 deprecation](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
+- Bug #270: Prevent null parameter on `mb_strlen` to avoid PHP 8.4 implicity nullable types deprecation (tehmaestro)
 
 
 2.0.19 February 13, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.20 under development
 ------------------------
 
-- no changes in this release.
+- Bug #270: Prevent null parameter on `mb_strlen` to avoid [PHP 8.4 deprecation](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 
 
 2.0.19 February 13, 2025

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -766,7 +766,7 @@ class Connection extends Component
         $params = array_merge(explode(' ', $name), $params);
         $command = '*' . count($params) . "\r\n";
         foreach ($params as $arg) {
-            $command .= '$' . mb_strlen($arg, '8bit') . "\r\n" . $arg . "\r\n";
+            $command .= '$' . mb_strlen($arg ?? '', '8bit') . "\r\n" . $arg . "\r\n";
         }
 
         \Yii::trace("Executing Redis Command: {$name}", __METHOD__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #270 

Fix for PHP 8.4 https://wiki.php.net/rfc/deprecate-implicitly-nullable-types