### PR TITLE
Fix #278: Prevent null parameter on SocketException to avoid PHP 8.4 null depreaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 redis extension Change Log
 2.0.21 under development
 ------------------------
 
+- Fix #278: Prevent null parameter on SocketException to avoid PHP 8.4 implicity nullable types deprecation (HenryVolkmer)
 - New #276: Added support for predis (antonshevelev)
 - New #276: Changed default value of yii\redis\Cache::$forceClusterMode to false (antonshevelev)
 - New #276: Implemented yii\redis\ConnectionInterface in yii\redis\Connection (antonshevelev)

--- a/src/SocketException.php
+++ b/src/SocketException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -15,7 +16,7 @@ use yii\db\Exception;
  */
 class SocketException extends Exception
 {
-    public function __construct($message = null, $code = 0, \Exception $previous = null)
+    public function __construct($message = null, $code = 0, ?\Exception $previous = null)
     {
         if (!YII_DEBUG) {
             $message = preg_replace('~AUTH \S+ \S+~', 'AUTH *** ***', $message);


### PR DESCRIPTION
…4 implicity nullable types deprecation (HenryVolkmer)

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #278 
