### PR TITLE
Fix infinite loop in parseResponse() when fread() returns empty string on broken socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 redis extension Change Log
 - Enh #281: PHP 7.3 support was removed to align with Yii2 minimum PHP version (@s1lver)
 - Enh #287: Applying Yii2 coding standards (@s1lver)
 - Fix #281: PHP 7.4 compatibility is now fixed (@s1lver)
+- Fix: Prevent infinite loop in `parseResponse()` when `fread()` returns empty string on broken socket (@dkostik)
 
 2.1.0 December 25, 2025
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 redis extension Change Log
 - Enh #281: PHP 7.3 support was removed to align with Yii2 minimum PHP version (@s1lver)
 - Enh #287: Applying Yii2 coding standards (@s1lver)
 - Fix #281: PHP 7.4 compatibility is now fixed (@s1lver)
-- Fix: Prevent infinite loop in `parseResponse()` when `fread()` returns empty string on broken socket (@dkostik)
+- Fix #291: Prevent infinite loop in `parseResponse()` when `fread()` returns empty string on broken socket (@dkostik)
 
 2.1.0 December 25, 2025
 -----------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1303,7 +1303,7 @@ parameters:
 			path: tests/RedisConnectionTest.php
 
 		-
-			message: '#^Parameter \#1 \$array_arg of function sort expects TArray of array, array\|bool\|string\|null given\.$#'
+			message: '#^Parameter \#1 \$array_arg of function sort expects (TArray of )?array, array\|bool\|string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/RedisConnectionTest.php

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -660,7 +660,7 @@ class Connection extends Component implements ConnectionInterface
                 $length = (int)$line + 2;
                 $data = '';
                 while ($length > 0) {
-                    if (($block = fread($this->socket, $length)) === false) {
+                    if (($block = fread($this->socket, $length)) === false || $block === '') {
                         throw new SocketException("Failed to read from socket.\nRedis command was: " . implode(' ', $params));
                     }
                     $data .= $block;

--- a/tests/RedisConnectionTest.php
+++ b/tests/RedisConnectionTest.php
@@ -384,4 +384,40 @@ class RedisConnectionTest extends TestCase
             $this->assertEquals($expected, $actual);
         }
     }
+
+    /**
+     * Test that parseResponse throws SocketException when fread() returns empty string
+     * on a broken socket, instead of looping forever in the bulk reply while($length > 0) loop.
+     *
+     * This simulates a Redis node dying mid-response during cluster failover/node replacement:
+     * the bulk reply header ($200\r\n) is received, but the body never arrives.
+     *
+     * @see https://github.com/yiisoft/yii2-redis/issues/XXX
+     */
+    public function testParseResponseBulkReplyBrokenSocket(): void
+    {
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        $this->assertNotFalse($pair, 'Failed to create socket pair');
+
+        [$client, $server] = $pair;
+        stream_set_timeout($client, 1);
+
+        // Simulate: Redis sends bulk reply header, then the node dies before sending the body
+        fwrite($server, "\$200\r\n");
+        fclose($server);
+
+        // Inject the fake socket into a Connection instance
+        $db = new Connection();
+        $pool = new \ReflectionProperty(Connection::class, '_pool');
+        $pool->setAccessible(true);
+        $pool->setValue($db, ['tcp://fake:6379' => $client]);
+
+        $db->hostname = 'fake';
+        $db->port = 6379;
+
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessage('Failed to read from socket');
+
+        $db->sendRawCommand("*2\r\n\$3\r\nGET\r\n\$3\r\nfoo\r\n", ['GET', 'foo']);
+    }
 }

--- a/tests/RedisConnectionTest.php
+++ b/tests/RedisConnectionTest.php
@@ -391,12 +391,10 @@ class RedisConnectionTest extends TestCase
      *
      * This simulates a Redis node dying mid-response during cluster failover/node replacement:
      * the bulk reply header ($200\r\n) is received, but the body never arrives.
-     *
-     * @see https://github.com/yiisoft/yii2-redis/issues/XXX
      */
     public function testParseResponseBulkReplyBrokenSocket(): void
     {
-        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
         $this->assertNotFalse($pair, 'Failed to create socket pair');
 
         [$client, $server] = $pair;
@@ -418,7 +416,7 @@ class RedisConnectionTest extends TestCase
         $db->port = 6379;
 
         $this->expectException(SocketException::class);
-        $this->expectExceptionMessage('Failed to read from socket');
+        $this->expectExceptionMessageMatches('/Failed to read from socket/');
 
         $this->invokeMethod($db, 'sendRawCommand', ["*2\r\n\$3\r\nGET\r\n\$3\r\nfoo\r\n", ['GET', 'foo']]);
     }

--- a/tests/RedisConnectionTest.php
+++ b/tests/RedisConnectionTest.php
@@ -402,9 +402,11 @@ class RedisConnectionTest extends TestCase
         [$client, $server] = $pair;
         stream_set_timeout($client, 1);
 
-        // Simulate: Redis sends bulk reply header, then the node dies before sending the body
+        // Simulate: Redis sends bulk reply header, then the node dies before sending the body.
+        // Use stream_socket_shutdown to close only the write side of the server,
+        // so fwrite() on the client still succeeds but fread() gets EOF after the header.
         fwrite($server, "\$200\r\n");
-        fclose($server);
+        stream_socket_shutdown($server, STREAM_SHUT_WR);
 
         // Inject the fake socket into a Connection instance
         $db = new Connection();

--- a/tests/RedisConnectionTest.php
+++ b/tests/RedisConnectionTest.php
@@ -418,6 +418,6 @@ class RedisConnectionTest extends TestCase
         $this->expectException(SocketException::class);
         $this->expectExceptionMessage('Failed to read from socket');
 
-        $db->sendRawCommand("*2\r\n\$3\r\nGET\r\n\$3\r\nfoo\r\n", ['GET', 'foo']);
+        $this->invokeMethod($db, 'sendRawCommand', ["*2\r\n\$3\r\nGET\r\n\$3\r\nfoo\r\n", ['GET', 'foo']]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

## Summary

When a Redis node dies mid-response (e.g. during cluster failover or node replacement), `fread()` returns `''` (empty string), **not** `false`.

The bulk reply parser in `parseResponse()` only checks for `=== false`:

```php
while ($length > 0) {
    if (($block = fread($this->socket, $length)) === false) {  // never triggers on ''!
        throw new SocketException("...");
    }
    $data .= $block;
    $length -= mb_strlen($block, '8bit');  // 0 -= 0 = no progress
}
```

This causes an **infinite loop** because:
- `fread()` returns `''` on a broken/timed-out socket (not `false`)
- `mb_strlen('', '8bit')` is `0`, so `$length` never decreases
- The `while ($length > 0)` loop never exits
- With `dataTimeout` set, each `fread()` blocks for N seconds before returning `''`

## Impact

In long-running workers (queue consumers, cron jobs), this causes the process to **hang permanently**. The retry/reconnect logic in `executeCommand()` never gets a chance to run because we're stuck inside `sendRawCommand()` → `parseResponse()`.

Logs are also never flushed (since flush typically happens at end of iteration), making the issue very hard to diagnose.

## Reproduction scenario

1. Worker has an open Redis connection
2. DevOps performs node replacement / cluster resharding
3. Worker sends a GET command
4. Redis sends bulk reply header (`$200\r\n`) then the node dies
5. `fgets()` reads the header successfully (small, fits in TCP buffer)
6. `fread()` tries to read the 202-byte body → broken socket → returns `''`
7. **Infinite loop** — worker hangs forever

## Fix

```php
// Before:
if (($block = fread($this->socket, $length)) === false) {

// After:
if (($block = fread($this->socket, $length)) === false || $block === '') {
```

This allows `SocketException` to be thrown, which triggers the existing retry/reconnect logic in `executeCommand()`.

## Test

Added `testParseResponseBulkReplyBrokenSocket` — uses `stream_socket_pair()` to simulate a partial bulk reply (header sent, server closed before body), verifying that `SocketException` is thrown instead of hanging.