### PR TITLE
Fix #292: Fixed `fwrite()` supplied resource is not a valid stream, bump version `predis/predis` to `3.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 redis extension Change Log
 - Fix #281: PHP 7.4 compatibility is now fixed (@s1lver)
 - Fix #291: Prevent infinite loop in `parseResponse()` when `fread()` returns empty string on broken socket (@dkostik)
 - Fix #292: Fixed `fwrite()` supplied resource is not a valid stream (@s1lver)
+- Enh #292: Bump version `predis/predis` to `3.4` 
 
 2.1.0 December 25, 2025
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Yii Framework 2 redis extension Change Log
 - Fix #281: PHP 7.4 compatibility is now fixed (@s1lver)
 - Fix #291: Prevent infinite loop in `parseResponse()` when `fread()` returns empty string on broken socket (@dkostik)
 - Fix #292: Fixed `fwrite()` supplied resource is not a valid stream (@s1lver)
-- Enh #292: Bump version `predis/predis` to `3.4` 
+- Enh #292: Bump version `predis/predis` to `3.4` (@s1lver)
 
 2.1.0 December 25, 2025
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 redis extension Change Log
 - Enh #287: Applying Yii2 coding standards (@s1lver)
 - Fix #281: PHP 7.4 compatibility is now fixed (@s1lver)
 - Fix #291: Prevent infinite loop in `parseResponse()` when `fread()` returns empty string on broken socket (@dkostik)
+- Fix #292: Fixed `fwrite()` supplied resource is not a valid stream (@s1lver)
 
 2.1.0 December 25, 2025
 -----------------------

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ down:			## Stop and remove containers, networks
 	docker compose down
 
 sh:			## Enter the container with the application
-	docker exec -it docker-yii2-redis-php-1 bash
+	docker exec -it yii2-redis-php-1 bash
 
 static-analysis:	## Run code static analyze. Params: {{ v=8.1 }}.
 	make build v=$(filter-out $@,$(v))

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.4 || ^8.0",
         "ext-openssl": "*",
         "yiisoft/yii2": "~2.0.50",
-        "predis/predis": "^3.4.*"
+        "predis/predis": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.4 || ^8.0",
         "ext-openssl": "*",
         "yiisoft/yii2": "~2.0.50",
-        "predis/predis": "^v2.3.0|3.3.*"
+        "predis/predis": "^3.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -535,18 +535,6 @@ parameters:
 			path: src/Connection.php
 
 		-
-			message: '#^Method yii\\redis\\ConnectionInterface\:\:executeCommand\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/ConnectionInterface.php
-
-		-
-			message: '#^Method yii\\redis\\ConnectionInterface\:\:executeCommand\(\) has parameter \$params with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/ConnectionInterface.php
-
-		-
 			message: '#^Binary operation "\+" between int\<0, max\>\|yii\\db\\ExpressionInterface and int\<0, max\>\|yii\\db\\ExpressionInterface results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -895,30 +883,6 @@ parameters:
 			path: src/Predis/PredisConnection.php
 
 		-
-			message: '#^Method yii\\redis\\Predis\\PredisConnection\:\:__call\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Predis/PredisConnection.php
-
-		-
-			message: '#^Method yii\\redis\\Predis\\PredisConnection\:\:executeCommand\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Predis/PredisConnection.php
-
-		-
-			message: '#^Method yii\\redis\\Predis\\PredisConnection\:\:executeCommand\(\) has parameter \$params with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Predis/PredisConnection.php
-
-		-
-			message: '#^Property yii\\redis\\Predis\\PredisConnection\:\:\$redisCommands type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Predis/PredisConnection.php
-
-		-
 			message: '#^Cannot call method executeCommand\(\) on array\|string\|yii\\redis\\ConnectionInterface\.$#'
 			identifier: method.nonObject
 			count: 3
@@ -1249,13 +1213,7 @@ parameters:
 			path: tests/RedisCacheTest.php
 
 		-
-			message: '#^Argument of an invalid type bool\|list\|string\|null supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: tests/RedisConnectionTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true and ''Reconnection…'' will always evaluate to true\.$#'
+			message: '#^Call to method PHPUnit\\Framework\\Assert::assertTrue\(\) with true and ''Reconnection…'' will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/RedisConnectionTest.php
@@ -1299,12 +1257,6 @@ parameters:
 		-
 			message: '#^Method yiiunit\\extensions\\redis\\RedisConnectionTest\:\:zRangeByScoreData\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/RedisConnectionTest.php
-
-		-
-			message: '#^Parameter \#1 \$array_arg of function sort expects (TArray of )?array, array\|bool\|string\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: tests/RedisConnectionTest.php
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -546,7 +546,7 @@ class Connection extends Component implements ConnectionInterface
      * for details on the mentioned reply types.
      * @throws Exception for commands that return [error reply](https://redis.io/topics/protocol#error-reply).
      */
-    public function executeCommand($name, $params = [])
+    public function executeCommand(string $name, array $params = [])
     {
         $this->open();
 

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -227,9 +227,9 @@ interface ConnectionInterface
     public function getIsActive(): bool;
 
     /**
-     * @param $name
-     * @param $params
+     * @param string $name
+     * @param array<mixed> $params
      * @return mixed
      */
-    public function executeCommand($name, $params = []);
+    public function executeCommand(string $name, array $params = []);
 }

--- a/src/Predis/PredisConnection.php
+++ b/src/Predis/PredisConnection.php
@@ -393,7 +393,7 @@ class PredisConnection extends Component implements ConnectionInterface
 
     /**
      * @param string $name
-     * @param array<string, mixed> $params
+     * @param array<mixed> $params
      * @return mixed|ErrorInterface|ResponseInterface
      * @throws Throwable
      */

--- a/src/Predis/PredisConnection.php
+++ b/src/Predis/PredisConnection.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
 declare(strict_types=1);
 
 namespace yii\redis\Predis;

--- a/src/Predis/PredisConnection.php
+++ b/src/Predis/PredisConnection.php
@@ -6,6 +6,7 @@ namespace yii\redis\Predis;
 
 use Predis\Client;
 use Predis\Connection\ConnectionException as PredisConnectionException;
+use Predis\Connection\Resource\Exception\StreamInitException;
 use Predis\Response\ErrorInterface;
 use Predis\Response\ResponseInterface;
 use Predis\Response\Status;
@@ -341,6 +342,7 @@ class PredisConnection extends Component implements ConnectionInterface
      * @return mixed|ErrorInterface|ResponseInterface
      * @throws InvalidConfigException
      * @throws PredisConnectionException
+     * @throws StreamInitException
      */
     public function executeCommand($name, $params = [])
     {
@@ -360,7 +362,7 @@ class PredisConnection extends Component implements ConnectionInterface
             for ($attempt = 0; $attempt <= $savedRetries; $attempt++) {
                 try {
                     return $this->executeCommandInternal($name, $params);
-                } catch (PredisConnectionException $e) {
+                } catch (PredisConnectionException | StreamInitException $e) {
                     $lastException = $e;
                     Yii::error($e, __METHOD__);
 

--- a/src/Predis/PredisConnection.php
+++ b/src/Predis/PredisConnection.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace yii\redis\Predis;
 
 use Predis\Client;
+use Predis\Connection\ConnectionException as PredisConnectionException;
 use Predis\Response\ErrorInterface;
 use Predis\Response\ResponseInterface;
 use Predis\Response\Status;
+use Throwable;
 use Yii;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
@@ -304,9 +306,23 @@ class PredisConnection extends Component implements ConnectionInterface
     public $options = [];
 
     /**
+     * @var int The number of times a command execution should be retried when a connection failure occurs.
+     * Defaults to 0 meaning no retries on failure.
+     * @since 2.2.0
+     */
+    public int $retries = 0;
+
+    /**
+     * @var int The retry interval in microseconds to wait between retry.
+     * Defaults to 0 meaning no wait.
+     * @since 2.2.0
+     */
+    public int $retryInterval = 0;
+
+    /**
      * @var Client|null redis connection
      */
-    protected $client;
+    protected ?Client $client = null;
 
     /**
      * Returns a value indicating whether the DB connection is established.
@@ -324,6 +340,7 @@ class PredisConnection extends Component implements ConnectionInterface
     /**
      * @return mixed|ErrorInterface|ResponseInterface
      * @throws InvalidConfigException
+     * @throws PredisConnectionException
      */
     public function executeCommand($name, $params = [])
     {
@@ -331,6 +348,46 @@ class PredisConnection extends Component implements ConnectionInterface
 
         Yii::debug("Executing Redis Command: $name " . implode(' ', $params), __METHOD__);
 
+        if ($this->retries <= 0) {
+            return $this->executeCommandInternal($name, $params);
+        }
+
+        $lastException = null;
+        $savedRetries = $this->retries;
+        $this->retries = 0;
+
+        try {
+            for ($attempt = 0; $attempt <= $savedRetries; $attempt++) {
+                try {
+                    return $this->executeCommandInternal($name, $params);
+                } catch (PredisConnectionException $e) {
+                    $lastException = $e;
+                    Yii::error($e, __METHOD__);
+
+                    if ($attempt < $savedRetries) {
+                        $this->close();
+                        if ($this->retryInterval > 0) {
+                            usleep($this->retryInterval);
+                        }
+                        $this->open();
+                    }
+                }
+            }
+        } finally {
+            $this->retries = $savedRetries;
+        }
+
+        throw $lastException;
+    }
+
+    /**
+     * @param string $name
+     * @param array<string, mixed> $params
+     * @return mixed|ErrorInterface|ResponseInterface
+     * @throws Throwable
+     */
+    private function executeCommandInternal(string $name, array $params)
+    {
         $command = $this->client->createCommand($name, $params);
         $response = $this->client->executeCommand(new CommandDecorator($command));
         if ($response instanceof Status) {
@@ -373,6 +430,7 @@ class PredisConnection extends Component implements ConnectionInterface
             return;
         }
         $this->client->disconnect();
+        $this->client = null;
     }
 
     /**

--- a/src/Predis/PredisConnection.php
+++ b/src/Predis/PredisConnection.php
@@ -66,7 +66,7 @@ class PredisConnection extends Component implements ConnectionInterface
     public const EVENT_AFTER_OPEN = 'afterOpen';
 
     /**
-     * @var array List of available redis commands.
+     * @var string[] List of available redis commands.
      * @see https://redis.io/commands
      */
     public $redisCommands = [
@@ -320,7 +320,7 @@ class PredisConnection extends Component implements ConnectionInterface
     public int $retries = 0;
 
     /**
-     * @var int The retry interval in microseconds to wait between retry.
+     * @var int The retry interval in microseconds to wait between retries.
      * Defaults to 0 meaning no wait.
      * @since 2.2.0
      */
@@ -345,12 +345,15 @@ class PredisConnection extends Component implements ConnectionInterface
     }
 
     /**
+     * @param string $name
+     * @param array<mixed> $params
      * @return mixed|ErrorInterface|ResponseInterface
      * @throws InvalidConfigException
      * @throws PredisConnectionException
      * @throws StreamInitException
+     * @throws Throwable
      */
-    public function executeCommand($name, $params = [])
+    public function executeCommand(string $name, array $params = [])
     {
         $this->open();
 
@@ -461,7 +464,7 @@ class PredisConnection extends Component implements ConnectionInterface
      * ```
      *
      * @param string $name name of the missing method to execute
-     * @param array $params method call arguments
+     * @param array<mixed> $params method call arguments
      * @return mixed
      * @throws InvalidConfigException
      */

--- a/tests/RedisConnectionTest.php
+++ b/tests/RedisConnectionTest.php
@@ -249,6 +249,7 @@ class RedisConnectionTest extends TestCase
         $redis->executeCommand('SADD', ['newset2', 'segtggttval', 'sv1', 'sv2', 'sv3']);
         $redis->executeCommand('ZADD', ['newz2', 2, 'ss', 3, 'pfpf']);
         $allKeys = $redis->executeCommand('KEYS', ['*']);
+        self::assertIsArray($allKeys);
         sort($allKeys);
         $this->assertEquals(['hash1', 'key1', 'newlist2', 'newset2', 'newz2'], $allKeys);
         $expected = [

--- a/tests/predis/sentinel/PredisConnectionRetryTest.php
+++ b/tests/predis/sentinel/PredisConnectionRetryTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
 namespace yiiunit\extensions\predis\sentinel;
 
 use yii\base\InvalidConfigException;

--- a/tests/predis/sentinel/PredisConnectionRetryTest.php
+++ b/tests/predis/sentinel/PredisConnectionRetryTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace yiiunit\extensions\predis\sentinel;
+
+use yii\base\InvalidConfigException;
+use yii\redis\LuaScriptBuilder;
+use yii\redis\Predis\PredisConnection;
+
+class PredisConnectionRetryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->getConnection(false);
+        parent::tearDown();
+    }
+
+    public function testDefaultRetriesIsZero(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertSame(0, $db->retries);
+    }
+
+    public function testDefaultRetryIntervalIsZero(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertSame(0, $db->retryInterval);
+    }
+
+    public function testExecuteCommandWithoutRetries(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('sentinel_retry_test_key', 'value1');
+        $this->assertEquals('value1', $db->get('sentinel_retry_test_key'));
+    }
+
+    public function testExecuteCommandWithRetriesSuccessOnFirstAttempt(): void
+    {
+        $db = $this->getConnection(true);
+        $db->retries = 3;
+
+        $db->set('sentinel_retry_test_key2', 'value2');
+        $this->assertEquals('value2', $db->get('sentinel_retry_test_key2'));
+    }
+
+    public function testRetryOnClosedConnection(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('sentinel_retry_persistent_key', 'persistent_value');
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+
+        $db->retries = 2;
+        $db->retryInterval = 1000;
+        $result = $db->get('sentinel_retry_persistent_key');
+        $this->assertEquals('persistent_value', $result);
+    }
+
+    public function testRetryWithWorkingReconnect(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('sentinel_retry_reconnect_key', 'before');
+
+        $db->retries = 3;
+        $db->retryInterval = 1000;
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+
+        $result = $db->get('sentinel_retry_reconnect_key');
+        $this->assertEquals('before', $result);
+        $this->assertTrue($db->getIsActive());
+        $db->close();
+    }
+
+    public function testCloseResetsClientToNull(): void
+    {
+        $db = $this->getConnection(true);
+        $this->assertNotNull($db->getClient());
+        $this->assertTrue($db->getIsActive());
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+    }
+
+    public function testReconnectAfterClose(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('sentinel_reconnect_test_key', 'before_close');
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+
+        $db->open();
+        $this->assertEquals('before_close', $db->get('sentinel_reconnect_test_key'));
+        $db->close();
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $db = $this->getConnection(true);
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+    }
+
+    public function testGetIsActiveWhenNotConnected(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertFalse($db->getIsActive());
+    }
+
+    public function testGetIsActiveWhenConnected(): void
+    {
+        $db = $this->getConnection(true);
+        $this->assertTrue($db->getIsActive());
+        $db->close();
+    }
+
+    public function testGetClientOpensConnection(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertFalse($db->getIsActive());
+        $client = $db->getClient();
+        $this->assertNotNull($client);
+        $db->close();
+    }
+
+    public function testGetLuaScriptBuilder(): void
+    {
+        $db = $this->getConnection(false);
+        $builder = $db->getLuaScriptBuilder();
+        $this->assertSame(LuaScriptBuilder::class, get_class($builder));
+    }
+
+    public function testOpenTriggersAfterOpenEvent(): void
+    {
+        $db = $this->getConnection(false);
+        $triggered = false;
+        $db->on(PredisConnection::EVENT_AFTER_OPEN, function () use (&$triggered) {
+            $triggered = true;
+        });
+        $db->open();
+        $this->assertTrue($triggered);
+        $db->close();
+    }
+
+    public function testOpenWithEmptyParametersThrowsException(): void
+    {
+        $db = new PredisConnection();
+        $db->parameters = null;
+
+        $this->expectException(InvalidConfigException::class);
+        $db->open();
+    }
+
+    public function testMagicCallForRedisCommand(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('sentinel_magic_test_key', 'magic_value');
+        $this->assertEquals('magic_value', $db->get('sentinel_magic_test_key'));
+    }
+
+    public function testExecuteCommandReturnsBoolForOkStatus(): void
+    {
+        $db = $this->getConnection(true);
+        $result = $db->set('sentinel_bool_test_key', 'val');
+        $this->assertTrue($result);
+    }
+
+    public function testExecuteCommandReturnsBoolForPong(): void
+    {
+        $db = $this->getConnection(true);
+        $result = $db->ping();
+        $this->assertTrue($result);
+    }
+}

--- a/tests/predis/sentinel/PredisConnectionRetryTest.php
+++ b/tests/predis/sentinel/PredisConnectionRetryTest.php
@@ -108,6 +108,7 @@ class PredisConnectionRetryTest extends TestCase
     {
         $db = $this->getConnection(true);
         $db->close();
+        $db->close();
         $this->assertFalse($db->getIsActive());
     }
 

--- a/tests/predis/sentinel/PredisConnectionRetryTest.php
+++ b/tests/predis/sentinel/PredisConnectionRetryTest.php
@@ -81,7 +81,7 @@ class PredisConnectionRetryTest extends TestCase
         $db->close();
     }
 
-    public function testCloseResetsClientToNull(): void
+    public function testCloseDeactivatesConnection(): void
     {
         $db = $this->getConnection(true);
         $this->assertNotNull($db->getClient());

--- a/tests/predis/sentinel/RedisConnectionTest.php
+++ b/tests/predis/sentinel/RedisConnectionTest.php
@@ -94,6 +94,7 @@ class RedisConnectionTest extends TestCase
         $redis->executeCommand('SADD', ['newset2', 'segtggttval', 'sv1', 'sv2', 'sv3']);
         $redis->executeCommand('ZADD', ['newz2', 2, 'ss', 3, 'pfpf']);
         $allKeys = $redis->executeCommand('KEYS', ['*']);
+        self::assertIsArray($allKeys);
         sort($allKeys);
         $this->assertEquals(['hash1', 'key1', 'newlist2', 'newset2', 'newz2'], $allKeys);
         $expected = [

--- a/tests/predis/standalone/PredisConnectionRetryTest.php
+++ b/tests/predis/standalone/PredisConnectionRetryTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+declare(strict_types=1);
+
 namespace yiiunit\extensions\predis\standalone;
 
 use Predis\Connection\ConnectionException as PredisConnectionException;

--- a/tests/predis/standalone/PredisConnectionRetryTest.php
+++ b/tests/predis/standalone/PredisConnectionRetryTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace yiiunit\extensions\predis\standalone;
+
+use Predis\Connection\ConnectionException as PredisConnectionException;
+use Predis\Connection\Resource\Exception\StreamInitException;
+use yii\base\InvalidConfigException;
+use yii\redis\LuaScriptBuilder;
+use yii\redis\Predis\PredisConnection;
+
+class PredisConnectionRetryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->getConnection(false);
+        parent::tearDown();
+    }
+
+    public function testDefaultRetriesIsZero(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertSame(0, $db->retries);
+    }
+
+    public function testDefaultRetryIntervalIsZero(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertSame(0, $db->retryInterval);
+    }
+
+    public function testExecuteCommandWithoutRetries(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('retry_test_key', 'value1');
+        $this->assertEquals('value1', $db->get('retry_test_key'));
+    }
+
+    public function testExecuteCommandWithRetriesSuccessOnFirstAttempt(): void
+    {
+        $db = $this->getConnection(true);
+        $db->retries = 3;
+
+        $db->set('retry_test_key2', 'value2');
+        $this->assertEquals('value2', $db->get('retry_test_key2'));
+    }
+
+    public function testRetryOnClosedConnection(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('retry_persistent_key', 'persistent_value');
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+
+        $db->retries = 2;
+        $db->retryInterval = 1000;
+        $result = $db->get('retry_persistent_key');
+        $this->assertEquals('persistent_value', $result);
+    }
+
+    public function testRetryThrowsAfterAllAttemptsExhausted(): void
+    {
+        $db = new PredisConnection([
+            'parameters' => 'tcp://redis:1?timeout=0.001',
+            'options' => [],
+        ]);
+        $db->retries = 2;
+        $db->retryInterval = 1000;
+
+        $thrown = null;
+        try {
+            $db->executeCommand('GET', ['nonexistent_key']);
+        } catch (PredisConnectionException | StreamInitException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertNotNull($thrown);
+    }
+
+    public function testRetriesPropertyPreservedAfterException(): void
+    {
+        $db = new PredisConnection([
+            'parameters' => 'tcp://redis:1?timeout=0.001',
+            'options' => [],
+        ]);
+        $db->retries = 5;
+        $db->retryInterval = 500;
+
+        try {
+            $db->executeCommand('GET', ['test']);
+        } catch (PredisConnectionException | StreamInitException $e) {
+        }
+
+        $this->assertSame(5, $db->retries);
+    }
+
+    public function testRetryIntervalCausesDelay(): void
+    {
+        $db = new PredisConnection([
+            'parameters' => 'tcp://redis:1?timeout=0.001',
+            'options' => [],
+        ]);
+        $db->retries = 1;
+        $db->retryInterval = 50000;
+
+        $start = microtime(true);
+        try {
+            $db->executeCommand('GET', ['test']);
+        } catch (PredisConnectionException | StreamInitException $e) {
+        }
+        $elapsed = (microtime(true) - $start) * 1000;
+
+        $this->assertGreaterThanOrEqual(40, $elapsed);
+    }
+
+    public function testRetryWithWorkingReconnect(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('retry_reconnect_key', 'before');
+
+        $db->retries = 3;
+        $db->retryInterval = 1000;
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+
+        $result = $db->get('retry_reconnect_key');
+        $this->assertEquals('before', $result);
+        $this->assertTrue($db->getIsActive());
+        $db->close();
+    }
+
+    public function testCloseResetsClientToNull(): void
+    {
+        $db = $this->getConnection(true);
+        $this->assertNotNull($db->getClient());
+        $this->assertTrue($db->getIsActive());
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+    }
+
+    public function testReconnectAfterClose(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('reconnect_test_key', 'before_close');
+
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+
+        $db->open();
+        $this->assertEquals('before_close', $db->get('reconnect_test_key'));
+        $db->close();
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $db = $this->getConnection(true);
+        $db->close();
+        $db->close();
+        $this->assertFalse($db->getIsActive());
+    }
+
+    public function testGetIsActiveWhenNotConnected(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertFalse($db->getIsActive());
+    }
+
+    public function testGetIsActiveWhenConnected(): void
+    {
+        $db = $this->getConnection(true);
+        $this->assertTrue($db->getIsActive());
+        $db->close();
+    }
+
+    public function testGetClientOpensConnection(): void
+    {
+        $db = $this->getConnection(false);
+        $this->assertFalse($db->getIsActive());
+        $client = $db->getClient();
+        $this->assertNotNull($client);
+        $db->close();
+    }
+
+    public function testGetLuaScriptBuilder(): void
+    {
+        $db = $this->getConnection(false);
+        $builder = $db->getLuaScriptBuilder();
+        $this->assertSame(LuaScriptBuilder::class, get_class($builder));
+    }
+
+    public function testOpenTriggersAfterOpenEvent(): void
+    {
+        $db = $this->getConnection(false);
+        $triggered = false;
+        $db->on(PredisConnection::EVENT_AFTER_OPEN, function () use (&$triggered) {
+            $triggered = true;
+        });
+        $db->open();
+        $this->assertTrue($triggered);
+        $db->close();
+    }
+
+    public function testOpenWithEmptyParametersThrowsException(): void
+    {
+        $db = new PredisConnection();
+        $db->parameters = null;
+
+        $this->expectException(InvalidConfigException::class);
+        $db->open();
+    }
+
+    public function testMagicCallForRedisCommand(): void
+    {
+        $db = $this->getConnection(true);
+        $db->set('magic_test_key', 'magic_value');
+        $this->assertEquals('magic_value', $db->get('magic_test_key'));
+    }
+
+    public function testExecuteCommandReturnsBoolForOkStatus(): void
+    {
+        $db = $this->getConnection(true);
+        $result = $db->set('bool_test_key', 'val');
+        $this->assertTrue($result);
+    }
+
+    public function testExecuteCommandReturnsBoolForPong(): void
+    {
+        $db = $this->getConnection(true);
+        $result = $db->ping();
+        $this->assertTrue($result);
+    }
+}

--- a/tests/predis/standalone/PredisConnectionRetryTest.php
+++ b/tests/predis/standalone/PredisConnectionRetryTest.php
@@ -75,14 +75,8 @@ class PredisConnectionRetryTest extends TestCase
         $db->retries = 2;
         $db->retryInterval = 1000;
 
-        $thrown = null;
-        try {
-            $db->executeCommand('GET', ['nonexistent_key']);
-        } catch (PredisConnectionException | StreamInitException $e) {
-            $thrown = $e;
-        }
-
-        $this->assertNotNull($thrown);
+        $this->expectException(StreamInitException::class);
+        $db->executeCommand('GET', ['nonexistent_key']);
     }
 
     public function testRetriesPropertyPreservedAfterException(): void
@@ -94,10 +88,13 @@ class PredisConnectionRetryTest extends TestCase
         $db->retries = 5;
         $db->retryInterval = 500;
 
+        $thrown = null;
         try {
             $db->executeCommand('GET', ['test']);
         } catch (PredisConnectionException | StreamInitException $e) {
+            $thrown = $e;
         }
+        $this->assertNotNull($thrown);
 
         $this->assertSame(5, $db->retries);
     }
@@ -138,7 +135,7 @@ class PredisConnectionRetryTest extends TestCase
         $db->close();
     }
 
-    public function testCloseResetsClientToNull(): void
+    public function testCloseDeactivatesConnection(): void
     {
         $db = $this->getConnection(true);
         $this->assertNotNull($db->getClient());

--- a/tests/predis/standalone/RedisConnectionTest.php
+++ b/tests/predis/standalone/RedisConnectionTest.php
@@ -93,6 +93,7 @@ class RedisConnectionTest extends TestCase
         $redis->executeCommand('SADD', ['newset2', 'segtggttval', 'sv1', 'sv2', 'sv3']);
         $redis->executeCommand('ZADD', ['newz2', 2, 'ss', 3, 'pfpf']);
         $allKeys = $redis->executeCommand('KEYS', ['*']);
+        self::assertIsArray($allKeys);
         sort($allKeys);
         $this->assertEquals(['hash1', 'key1', 'newlist2', 'newset2', 'newz2'], $allKeys);
         $expected = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | 

When using Redis Sentinel, if the connection is interrupted, an error occurs: `fwrite(): supplied resource is not a valid stream resource.`